### PR TITLE
fix: fix the broken URL of Helm binaries

### DIFF
--- a/tool/genmanifest.sh
+++ b/tool/genmanifest.sh
@@ -15,7 +15,7 @@ TAG=`$ROOT/tool/tag.sh`
 
 if ! [ -x "$(command -v helm)" ]; then
   echo 'Error: helm is not installed.'
-  wget https://storage.googleapis.com/kubernetes-helm/helm-v2.11.0-linux-amd64.tar.gz -O /tmp/helm.tar.gz
+  wget https://get.helm.sh/helm-v2.11.0-linux-amd64.tar.gz -O /tmp/helm.tar.gz
   tar -xvf /tmp/helm.tar.gz
   export PATH=$PATH:$PWD/linux-amd64/
 fi


### PR DESCRIPTION
The original link to get Helm binaries is broken and may be taken over by anyone.

We simply fix this by replacing the link with the official one.